### PR TITLE
Update go.mod and add automatic testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@
 on:
   push:
     branches:
-      - main 
+      - master 
   pull_request:
     branches:
-      - main
+      - master
 
 name: run tests
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+# https://github.com/jandelgado/golang-ci-template-github-actions
+on:
+  push:
+    branches:
+      - main 
+  pull_request:
+    branches:
+      - main
+
+name: run tests
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run linters
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.29
+
+  test:
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Install Go
+      if: success()
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run tests
+      run: go test ./... -v -covermode=count

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.17.x]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/koeng101/go-apriltag
+module github.com/twitchyliquid64/go-apriltag
 
 go 1.17


### PR DESCRIPTION
Embarrassingly, in go.mod I have left `module github.com/koeng101/go-apriltag`, whereas it should have been `module github.com/twitchyliquid64/go-apriltag` . This PR fixes that. 

I also added in automatic linting and testing for CI. Unfortunately, it appear go-apriltag fails at compiling on windows (https://github.com/Koeng101/go-apriltag/runs/3709429600), but I don't use windows (and apparently no one else does for this package) so I removed it from the CI tests. Ubuntu and macOSX pass tests, though.

Had to test a few things on master branch, so a squash+merge would probably be best.